### PR TITLE
Fix usage of Python in __texSetup__.sh

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,35 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+
+# see https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: image/
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/image/scripts/__texSetup__.sh
+++ b/image/scripts/__texSetup__.sh
@@ -21,7 +21,7 @@ fi
 
 __tex__relativeDocument="${__tex__relativeDocument:-}"
 if [[ -z "$__tex__relativeDocument" ]]; then
-  export __tex__relativeDocument=$(python -c "import os.path; print os.path.relpath('$__tex__fullDocument','${__tex__currentDir}')")
+  export __tex__relativeDocument=$(python3 -c "import os.path; print(os.path.relpath('$__tex__fullDocument','${__tex__currentDir}'))")
 fi
 
 __tex__document="${__tex__document:-}"


### PR DESCRIPTION
When running the image via

```shell
docker run -it -v `pwd`:/doc/ -v `pwd`/fonts/:/usr/share/fonts/external/ thomasweise/texlive xelatex.sh doc.tex
```

I am getting an error

```
/usr/bin/__texSetup__.sh: line 24: python: command not found
```

This line seems to calculate a relative path and since `python` is not available on the Docker image, it results in the following log output:

```
You want to compile document '', corresponding to full path '/doc/cv-lihs.tex', which is '' relative to current directory '/doc'.
First we will do some cleaning up temporary files from other LaTeX runs and also delete any pre-existing version of '.pdf'.
```

Quick check revealed that `python3` is available on the image, so using `python3` instead of `python` and adding `()` to the `print` command fixed the issue for me.